### PR TITLE
ensure that the generator is valid before calling next

### DIFF
--- a/src/QCheck/FP.php
+++ b/src/QCheck/FP.php
@@ -161,7 +161,7 @@ class FP {
 
     static function takeNth($n, $coll) {
         $coll = self::iterator($coll);
-        for ($coll->rewind(); $coll->valid(); $coll->next()) {
+        for ($coll->rewind(); $coll->valid(); $coll->valid() && $coll->next()) {
             yield $coll->current();
             for ($i = 0; $i < $n - 1 && $coll->valid(); ++$i) {
                 $coll->next();


### PR DESCRIPTION
HHVM raises an exception when calling `next()` on a "empty" generator (see https://travis-ci.org/krtek4/php-quickcheck/jobs/40710346)

This commit tries to ensure that we still have values before calling next().
