### PR TITLE
Improvement in regards to testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/phpunit.xml
 vendor/

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
     },
     "autoload": {
         "psr-4": {"QCheck\\": "src/QCheck/"}
+    },
+    "autoload-dev": {
+        "psr-4": {"QCheck\\": "test/QCheck/"}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-gmp": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*"
+        "phpunit/phpunit": "^4.8"
     },
     "autoload": {
         "psr-4": {"QCheck\\": "src/QCheck/"}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+
+    backupGlobals="false"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestSize="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="vendor/autoload.php"
+    checkForUnintentionallyCoveredCode="true"
+    colors="true"
+    forceCoversAnnotation="true"
+    verbose="true"
+>
+    <php>
+        <ini name="xdebug.max_nesting_level" value="9999"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="QuickCheck Test Suite">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+            <exclude>
+                <directory suffix=".php">test</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" showUncoveredFiles="true" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
Improvements in regards to testing:

- Adds a PHPUnit config file (including entries for coverage log and php ini setting for xDebug)
- Adds `phpunit.xml` to gitignore (so developers can override the config from a `phpunit.xml` file)
- Updates the PHPUnit version
- Adds composer autoloading for test classes

For improvements could include:
- Pushing the coverage log from Travis to [Coveralls](https://coveralls.io/) or [CodeCov](https://codecov.io/)
- Adding [`@covers` annotations](https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.covers) to test methods to have more strict coverage reporting
- [Adding a "test" call to composer `scripts` section](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands)