### PR TITLE
Correction on posInts and negInts; non-gmp PHP setups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "description": "a generative testing library",
     "license": "BSD-3-Clause",
     "require": {
-        "php-64bit": ">=5.5.0",
-        "ext-gmp": "*"
+        "php-64bit": ">=5.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/src/QCheck/Generator.php
+++ b/src/QCheck/Generator.php
@@ -564,7 +564,7 @@ class Generator
     public static function posInts()
     {
         return self::ints()->fmap(function ($x) {
-            return abs($x);
+            return abs($x)+1; // produce 1 for 0 etc
         });
     }
 
@@ -575,6 +575,32 @@ class Generator
      * @return Generator
      */
     public static function negInts()
+    {
+        return self::ints()->fmap(function ($x) {
+            return -abs($x)-1; // produce -1 for 0 etc.
+        });
+    }
+
+    /**
+     * creates a generator that produces non-negative integers bounded by
+     * the generators size parameter.
+     *
+     * @return Generator
+     */
+    public static function nonNegInts()
+    {
+        return self::ints()->fmap(function ($x) {
+            return abs($x);
+        });
+    }
+
+    /**
+     * creates a generator that produces non-positive integers bounded by
+     * the generators size parameter.
+     *
+     * @return Generator
+     */
+    public static function nonPosInts()
     {
         return self::ints()->fmap(function ($x) {
             return -abs($x);

--- a/src/QCheck/Generator.php
+++ b/src/QCheck/Generator.php
@@ -582,6 +582,32 @@ class Generator
     }
 
     /**
+     * creates a generator that produces strictly positive integers bounded by
+     * the generators size parameter.
+     *
+     * @return Generator
+     */
+    public static function strictlyPosInts()
+    {
+        return self::ints()->fmap(function ($x) {
+            return abs($x)+1;
+        });
+    }
+
+    /**
+     * creates a generator that produces strictly negative integers bounded by
+     * the generators size parameter.
+     *
+     * @return Generator
+     */
+    public static function strictlyNegInts()
+    {
+        return self::ints()->fmap(function ($x) {
+            return -abs($x)-1;
+        });
+    }
+
+    /**
      * creates a generator that produces values from specified generators based on
      * likelihoods. The likelihood of a generator being chosen is its likelihood divided
      * by the sum of all likelihoods.

--- a/src/QCheck/Generator.php
+++ b/src/QCheck/Generator.php
@@ -564,7 +564,7 @@ class Generator
     public static function posInts()
     {
         return self::ints()->fmap(function ($x) {
-            return abs($x)+1; // produce 1 for 0 etc
+            return abs($x);
         });
     }
 
@@ -575,32 +575,6 @@ class Generator
      * @return Generator
      */
     public static function negInts()
-    {
-        return self::ints()->fmap(function ($x) {
-            return -abs($x)-1; // produce -1 for 0 etc.
-        });
-    }
-
-    /**
-     * creates a generator that produces non-negative integers bounded by
-     * the generators size parameter.
-     *
-     * @return Generator
-     */
-    public static function nonNegInts()
-    {
-        return self::ints()->fmap(function ($x) {
-            return abs($x);
-        });
-    }
-
-    /**
-     * creates a generator that produces non-positive integers bounded by
-     * the generators size parameter.
-     *
-     * @return Generator
-     */
-    public static function nonPosInts()
     {
         return self::ints()->fmap(function ($x) {
             return -abs($x);

--- a/src/QCheck/Random.php
+++ b/src/QCheck/Random.php
@@ -38,21 +38,9 @@ class Random
     {
         $this->seed = self::mask($seed ^ self::MULTIPLIER);
     }
-
-    protected function ival($i) {
-      if (function_exists('gmp_intval')) return gmp_val($i);
-      return intval($i);
-    }
-
-    protected function imul($a, $b) {
-      if (function_exists('gmp_mul')) return gmp_mul($a, $b);
-      return $a * $b;
-    }
-
-
     protected function next($bits)
     {
-        $temp = self::ival(self::imul($this->seed, self::MULTIPLIER));
+        $temp = gmp_intval(gmp_mul($this->seed, self::MULTIPLIER));
         $this->seed = self::mask($temp + self::ADDEND);
         return self::i32(self::rshiftu($this->seed, (48 - $bits)));
     }

--- a/src/QCheck/Random.php
+++ b/src/QCheck/Random.php
@@ -41,7 +41,9 @@ class Random
     }
     protected function next($bits)
     {
-        $temp = self::general_intval(self::general_int_mul($this->seed, self::MULTIPLIER));
+        $temp = function_exists('gmp_mul') ?
+            gmp_intval(gmp_mul($this->seed, self::MULTIPLIER)) :
+            self::int_mul($this->seed, self::MULTIPLIER);
         $this->seed = self::mask($temp + self::ADDEND);
 
         return self::i32(self::rshiftu($this->seed, (48 - $bits)));
@@ -56,20 +58,9 @@ class Random
         return $this->next(32);
     }
 
-    public function general_int_mul($a, $b) {
-      if (function_exists("gmp_mul")) return gmp_mul($a, $b);
-      return self::int_mul($a, $b);
-    }
-
-    public function general_intval($a) {
-      if (function_exists("gmp_intval")) return gmp_intval($a);
-      return intval($a);
-    }
-
-    // multiplication with only shifts and ands
     // does Java/C/Go-like overflow
     // http://stackoverflow.com/questions/4456442/multiplication-of-two-integers-using-bitwise-operators
-    public function int_mul($a, $b)
+    public static function int_mul($a, $b)
     {
         $result = 0;
         while ($b != 0) {
@@ -86,7 +77,7 @@ class Random
     }
 
     // addition with only shifts and ands
-    public function int_add($x, $y)
+    public static function int_add($x, $y)
     {
         if ($y == 0) {
             return $x;

--- a/src/QCheck/Random.php
+++ b/src/QCheck/Random.php
@@ -38,9 +38,21 @@ class Random
     {
         $this->seed = self::mask($seed ^ self::MULTIPLIER);
     }
+
+    protected function ival($i) {
+      if (function_exists('gmp_intval')) return gmp_val($i);
+      return intval($i);
+    }
+
+    protected function imul($a, $b) {
+      if (function_exists('gmp_mul')) return gmp_mul($a, $b);
+      return $a * $b;
+    }
+
+
     protected function next($bits)
     {
-        $temp = gmp_intval(gmp_mul($this->seed, self::MULTIPLIER));
+        $temp = self::ival(self::imul($this->seed, self::MULTIPLIER));
         $this->seed = self::mask($temp + self::ADDEND);
         return self::i32(self::rshiftu($this->seed, (48 - $bits)));
     }


### PR DESCRIPTION
The changes to Generator ensure that posInts() and negInts() don't return 0. And I added nonNegInts() and nonPosInts() for those times where one wants to include zero.

I'm not so sure of the other changes. Our PHP version doesn't have the gmp math extensions compiled in, and so I used standard intval and multiplication in Random.php 