### PR TITLE
Make failure condition of constraint consistent

### DIFF
--- a/src/QuickCheck/PHPUnit/PropertyConstraint.php
+++ b/src/QuickCheck/PHPUnit/PropertyConstraint.php
@@ -10,7 +10,7 @@ class PropertyConstraint extends Constraint
      * @var int
      */
     private $size;
-    
+
     /**
      * @var array
      */
@@ -21,7 +21,7 @@ class PropertyConstraint extends Constraint
         $this->size = $n;
         $this->opts = $opts;
     }
-    
+
     public static function check($n = 100, array $opts = [])
     {
         return new self($n, $opts);
@@ -35,7 +35,7 @@ class PropertyConstraint extends Constraint
 
     protected function matches($other): bool
     {
-        return @$other['result'] === true;
+        return $other['result'] && !($other['result'] instanceof \Exception);
     }
 
     public function toString(): string


### PR DESCRIPTION
Currently the constraint expects the property fn to return strictly
boolean `true`. The `\QuickCheck\Property::shrinkLoop` [method](https://github.com/steos/php-quickcheck/blob/master/src/QuickCheck/Property.php#L90) on the other
hand allows any truthy value except exceptions (which is closer to
clojure.test.check behavior.

```php
if (!$result || $result instanceof \Exception) {
```

This PR makes the behavior of the PHPUnit constraint consistent with
the check in `\QuickCheck\Property`.