### PR TITLE
Add support for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 dist: trusty
 php:
+  - 7.3
   - 7.4
 install: composer install
 before_script:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ All credit goes to clojure.test.check, this project is mostly just a port.
 
 ## Requirements
 
-Requires PHP 7.4.x with 64 bit integers. The gmp extension is recommended but not required.
+Requires PHP 7.3.x with 64 bit integers. The gmp extension is recommended but not required.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "a generative testing library",
     "license": "BSD-3-Clause",
     "require": {
-        "php-64bit": ">=7.4.0"
+        "php-64bit": ">=7.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"


### PR DESCRIPTION
## Changes:

* Replace usage of PHP 7.4 only fn() syntax with 7.0 function ()
* Expand PHP version constraint in composer.json to include 7.3
* Add PHP 7.3 build to travis

## Rationale

I realize it's nice to be able to use the PHP 7.4 arrow functions, but limiting the project to 7.4 and newer effectively prohibits many active projects from using quickcheck.
I'm sure I can't use a 7.4 only quickcheck for at least another year.
Please accept this PR and support 7.3 for the time being, at least for the next 12 months, maybe even consider allowing it for the next 24 months.

Closes https://github.com/steos/php-quickcheck/issues/17