### PR TITLE
Upgrade to PHPUnit 9

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /composer.lock
 /.phpunit.result.cache
 /.idea/
+.vscode

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/console": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.1"
     },
     "autoload": {
         "psr-4": {"QuickCheck\\": "src/QuickCheck/"}

--- a/doc/phpunit.md
+++ b/doc/phpunit.md
@@ -7,16 +7,18 @@ Similar to `Property::check`, the method takes the size and allows also passing 
 ```php
 public function testStringsAreLessThanTenChars()
 {
-    $property = Property::forAll([Gen::strings()], function ($s): bool {
-        return 10 > strlen($s);
-    });
+    $property = Property::forAll(
+        [Gen::strings()],
+        fn ($s): bool => 10 > strlen($s)
+    );
+
     $this->assertThat($property, PropertyConstraint::check(50)); // will fail
 }
 ```
 
 The assertion will delegate to `Property::check($size, $seed)`, and if the function returns anything but `true`, it will display a formatted failure description.
 
-```
+```txt
 Failed asserting that property is true.
 Tests runs: 16, failing size: 15, seed: 1578486446175, smallest shrunk value(s):
 array (

--- a/src/QuickCheck/PHPUnit/PropertyConstraint.php
+++ b/src/QuickCheck/PHPUnit/PropertyConstraint.php
@@ -37,7 +37,7 @@ class PropertyConstraint extends Constraint
         return $this;
     }
 
-    public function evaluate($prop, string $description = '', bool $returnResult = false): self
+    public function evaluate($prop, string $description = '', bool $returnResult = false): ?bool
     {
         $result = Property::check($prop, $this->numTests, $this->seed);
         return parent::evaluate($result, $description, $returnResult);

--- a/test/QuickCheck/PHPUnitIntegrationTest.php
+++ b/test/QuickCheck/PHPUnitIntegrationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace QuickCheck;
+
+use PHPUnit\Framework\TestCase;
+use QuickCheck\Generator as Gen;
+use QuickCheck\PHPUnit\PropertyConstraint;
+
+class PHPUnitIntegrationTest extends TestCase {
+    /**
+     * Test example from PHPUnit integration documentation
+     */
+    public function testStringsAreLessThanTenChars()
+    {
+        $property = Property::forAll(
+            [Gen::strings()],
+            fn ($s): bool => 10 > strlen($s)
+        );
+
+        $this->assertFalse(
+            PropertyConstraint::check(50)->evaluate(
+                $property,
+                'Expected property to fail',
+                true
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR:

1. Upgrades PHPUnit to the latest version (9 at time of writing)
2. Fixes method signature mismatch on `PropertyConstraint::evaluate`
3. Adds a sanity check test that verifies the PHPUnit example works as expected
4. Updates docs to use PHP 7.4 style closures, since min. version is 7.4