### PR TITLE
Update the Dockerfile to start FROM php:7.3

### DIFF
--- a/dev-env/Dockerfile
+++ b/dev-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.1-cli
+FROM php:7.3.18-cli
 RUN apt-get update && apt-get install -y less git libgmp10-dev unzip
 RUN docker-php-ext-configure gmp && docker-php-ext-install -j$(nproc) gmp
 RUN pecl install xdebug && docker-php-ext-enable xdebug


### PR DESCRIPTION
As mention in the issue, https://github.com/steos/php-quickcheck/issues/27 we wanted to have PHP 7.3 in the Dockerfile as it's written in the `composer.json` requirements